### PR TITLE
ci: add tests for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,16 @@
-name: Testing
+name: Testing Go Installer
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
-  test-go-installer:
-    runs-on: ubuntu-latest
+  os_matrix:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
       - name: Testing


### PR DESCRIPTION
Thank you for the project. 

This commit adds test for mac and windows based runner in the CI for testing. 

I tested on my personal fork. 
Ref: https://github.com/kranurag7/go-installer/pull/1
