### PR TITLE
Add support for both curl and wget in installation process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Testing
         run: ./test.sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img align="right" src="https://user-images.githubusercontent.com/36763164/169433445-04f8485b-aa8d-45d0-a3cf-6e69c6456b2f.png" width="33%">
 
-> Install Golang on Linux or Mac <strike>with hassle of environment variables setting</strike>.  
+> Install Golang on Linux or Mac <strike>with hassle of environment variables setting</strike>.
 
 ![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)
 [![.github/workflows/test.yml](https://github.com/kerolloz/go-installer/actions/workflows/test.yml/badge.svg)](https://github.com/kerolloz/go-installer/actions/workflows/test.yml)
@@ -17,9 +17,7 @@
 
 You can _clone_ the repository and then run `bash go.sh`.
 
-Or by simply running whatever suits you from the following commands (`wget`[^1] or `curl`):
-
-[^1]: the script depends on wget ([1](https://github.com/kerolloz/go-installer/blob/836e09a79411cda39879a0ce8f69f199f4423562/go.sh#L67-L71), [2](https://github.com/kerolloz/go-installer/blob/836e09a79411cda39879a0ce8f69f199f4423562/go.sh#L132))
+Or by simply running whatever suits you from the following commands (`wget` or `curl`):
 
 ```bash
 # downloads then runs the script
@@ -27,14 +25,14 @@ wget https://git.io/go-installer.sh && bash go-installer.sh
 ```
 
 ```bash
-# doesn't download the script ~ runs the script directly 
+# doesn't download the script ~ runs the script directly
 bash <(curl -sL https://git.io/go-installer)
 ```
 
 Now, you can go grab a cup of coffee :coffee:, sit back :relieved: and relax while the magic happens! :crystal_ball:
 
 > **Note**  
-> By default the script will create `.go` and `go` folders on your _HOME_ directory & add the needed variables to your _PATH_ variable.  
+> By default the script will create `.go` and `go` folders on your _HOME_ directory & add the needed variables to your _PATH_ variable.
 
 `$HOME/.go` is where Go will be installed.
 `$HOME/go` is the default workspace.

--- a/go.sh
+++ b/go.sh
@@ -82,15 +82,28 @@ function extract_version_from() {
   echo "$version"
 }
 
+function get_download_command() {
+  if command -v curl &>/dev/null; then
+    echo "curl -s"
+  elif command -v wget &>/dev/null; then
+    echo "wget -qO-"
+  else
+    echo "$($TEXT_COLOR $RED)Error: Neither curl nor wget is available. Please install one of them.${RESET}" >&2
+    exit 1
+  fi
+}
+
 function find_version_link() {
   file_name="go$version_regex.$platform.tar.gz"
   link_regex="dl/$file_name"
   go_website="https://go.dev/"
 
+  download_command=$(get_download_command)
+
   latest_version_link="$go_website$(
-    wget -qO- "$go_website/dl/" | # get the HTML of golang page
-      grep -o "$link_regex" | # select installation links
-      head -1 # only get the first link i.e.(latest version)
+    $download_command "$go_website/dl/" | # get the HTML of golang page
+      grep -o "$link_regex" |             # select installation links
+      head -1                             # only get the first link i.e.(latest version)
   )"
 
   latest_version_file_name=$(grep -o "$file_name" <<<"$latest_version_link")
@@ -155,13 +168,22 @@ function install_go() {
     tput smul
   )$VERSION${RESET})..."
 
-  # wget2 v2.1.0 changed --show-progress to --force-progress, so we need to check which one to use
-  progress_arg="--show-progress"
-  wget --help | grep -q -- --force-progress && progress_arg="--force-progress"
+  download_command=$(get_download_command)
 
-  if ! wget --quiet --continue $progress_arg "$latest_version_link"; then
-    echo "$($TEXT_COLOR $RED)Download failed!"
-    exit 1
+  if [[ $download_command == "curl -s" ]]; then
+    if ! curl -fSL --progress-bar "$latest_version_link" -o "$latest_version_file_name"; then
+      echo "$($TEXT_COLOR $RED)Download failed!${RESET}"
+      exit 1
+    fi
+  else
+    # wget2 v2.1.0 changed --show-progress to --force-progress, so we need to check which one to use
+    progress_arg="--show-progress"
+    wget --help | grep -q -- --force-progress && progress_arg="--force-progress"
+
+    if ! wget --quiet --continue $progress_arg "$latest_version_link"; then
+      echo "$($TEXT_COLOR $RED)Download failed!${RESET}"
+      exit 1
+    fi
   fi
 
   [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
@@ -221,7 +243,7 @@ function update_go() {
     # bypass read option
     option=""
   else
-      echo -e "Do you want to install $($TEXT_COLOR $GREEN)Go($latest)${RESET} and remove $($TEXT_COLOR $RED)Go($current)${RESET}? [ENTER(yes)/n]: \c"
+    echo -e "Do you want to install $($TEXT_COLOR $GREEN)Go($latest)${RESET} and remove $($TEXT_COLOR $RED)Go($current)${RESET}? [ENTER(yes)/n]: \c"
     read -r option
   fi
 
@@ -274,8 +296,8 @@ function main() {
       ;;
     esac
   elif [[ $# > 2 ]]; then
-      print_help
-      exit
+    print_help
+    exit
   fi
 
   what_platform


### PR DESCRIPTION
This PR enables installer script to support both curl and wget for downloading Go and addresses the issue where wget is not pre-installed on some Linux distributions:
- #20 

The changes include:

1. Added a new function `get_download_command()` to detect and use either curl or wget.
2. Modified the `find_version_link()` function to use the available download command.
3. Updated the `install_go()` function to handle downloads with either curl or wget.
4. Updated the README.md to reflect the new requirements and remove wget-specific mentions.

<sub> Closes #20 </sub>